### PR TITLE
use string property in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"


### PR DESCRIPTION
using the string should fix that nvm can't find the node version
