### PR TITLE
update for accord v0.13.0 breaking change

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -131,4 +131,4 @@ module.exports = (opts) ->
           compiler = _.find @roots.config.compilers, (c) ->
             _.contains(c.extensions, path.extname(template).substring(1))
           compiler.renderFile(template, locals)
-            .then((res) => @util.write("#{t.path(entry)}.html", res))
+            .then((res) => @util.write("#{t.path(entry)}.html", res.result))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coveralls": "2.x",
     "istanbul": "0.3.x",
     "mocha": "1.x",
-    "roots": "3.0.0-rc.10",
+    "roots": "3.0.0-rc.11",
     "mockery": "1.4.x"
   },
   "scripts": {


### PR DESCRIPTION
Updates roots-contentful to be compatible with a recent breaking change to accord's API introduced in version [0.13.0](https://github.com/jenius/accord/releases/tag/v0.13.0) that's been included in the latest release of roots (3.0.0-rc.11).

This is a breaking change for anyone using an earlier version of roots, you must upgrade to `3.0.0-rc.11`.