### PR TITLE
Fix single entry bug

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -127,8 +127,8 @@ module.exports = (opts) ->
         if not t.template then return W.resolve()
         W.map t.content, (entry) =>
           template = path.join(@roots.root, t.template)
-          locals   = _.merge(@roots.config.locals, entry: entry)
+          @roots.config.locals.entry = entry
           compiler = _.find @roots.config.compilers, (c) ->
             _.contains(c.extensions, path.extname(template).substring(1))
-          compiler.renderFile(template, locals)
+          compiler.renderFile(template, @roots.config.locals)
             .then((res) => @util.write("#{t.path(entry)}.html", res.result))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coveralls": "2.x",
     "istanbul": "0.3.x",
     "mocha": "1.x",
-    "roots": "3.0.0-rc.11",
+    "roots": "3.0.x",
     "mockery": "1.4.x"
   },
   "scripts": {

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -27,8 +27,6 @@ mock_contentful = (opts = {}) ->
       name: 'Blog Post'
       displayField: 'title'
 
-  if opts.entry then opts.entries = [opts.entry]
-
   mockery.registerMock 'contentful',
     createClient: ->
       contentType: -> W.resolve(opts.content_type)
@@ -56,7 +54,7 @@ describe 'config', ->
   after -> unmock_contentful()
 
 describe 'contentful content type fields', ->
-  before -> mock_contentful(entry: {fields: {sys: 'test'}})
+  before -> mock_contentful(entries: [{fields: {sys: 'test'}}])
 
   it 'should throw an error if `sys` is a field name', ->
     compile_fixture.call(@, 'basic').should.be.rejected
@@ -67,7 +65,7 @@ describe 'basic compile', ->
   before (done) ->
     @title = 'Throw Some Ds'
     @body  = 'Rich Boy selling crick'
-    mock_contentful(entry: {fields: {title: @title, body: @body}})
+    mock_contentful(entries: [{fields: {title: @title, body: @body}}])
     compile_fixture.call(@, 'basic').then(-> done()).catch(done)
 
   it 'compiles basic project', ->
@@ -85,7 +83,7 @@ describe 'custom name for view helper local', ->
   before (done) ->
     @title = 'Throw Some Ds'
     @body  = 'Rich Boy selling crack'
-    mock_contentful(entry: {fields: {title: @title, body: @body}})
+    mock_contentful(entries: [{fields: {title: @title, body: @body}}])
     compile_fixture.call(@, 'custom_name').then(-> done()).catch(done)
 
   it 'has contentful data available in views under a custom name', ->
@@ -101,7 +99,7 @@ describe 'single entry views', ->
       @title = 'Real Talk'
       @body  = 'I\'m not about to sit up here, and argue about who\'s to blame.'
       mock_contentful
-        entry: {fields: {title: @title, body: @body}},
+        entries: [{fields: {title: @title, body: @body}}],
         content_type: {name: 'Blog Post', displayField: 'title'}
       compile_fixture.call(@, 'single_entry').then(-> done()).catch(done)
 
@@ -148,7 +146,7 @@ describe 'single entry views', ->
       @body  = 'I\'m not about to sit up here, and argue about who\'s to blame.'
       @category = 'greatest_hits'
       mock_contentful
-        entry: {fields: {title: @title, body: @body, category: @category}},
+        entries: [{fields: {title: @title, body: @body, category: @category}}],
         content_type: {name: 'Blog Post', displayField: 'title'}
       compile_fixture.call(@, 'single_entry_custom').then(-> done()).catch(done)
 


### PR DESCRIPTION
This fixes a bug when compiling single entry views where locals from previous entry's compiles are not cleared for the next single entry, so an entry with an undefined field might compile with the defined value from a previous single entry.