### PR TITLE
Improve config

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -45,6 +45,7 @@ module.exports = (opts) ->
     ###
 
     configure_content = (types) ->
+      if _.isPlainObject(types) then types = reconfigure_alt_type_config(types)
       W.map types, (t) ->
         if not t.id then return W.reject(errors.no_type_id)
         t.filters ?= {}
@@ -55,6 +56,20 @@ module.exports = (opts) ->
               t.path ?= (e) -> "#{t.name}/#{S(e[res.displayField]).slugify().s}"
             return t
         return W.resolve(t)
+
+    ###*
+     * Reconfigures content types set in app.coffee using an object instead of
+     * an array. The keys of the object set as the `name` option in the config
+     * @param {Object} types - content_types set in app.coffee extension config
+     * @return {Promise} - returns an array of content types
+    ###
+
+    reconfigure_alt_type_config = (types) ->
+      _.reduce types, (res, type, k) ->
+        type.name = k
+        res.push(type)
+        res
+      , []
 
     ###*
      * Fetches data from Contentful for content types, and formats the raw data

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -127,8 +127,8 @@ module.exports = (opts) ->
         if not t.template then return W.resolve()
         W.map t.content, (entry) =>
           template = path.join(@roots.root, t.template)
-          locals   = _.merge(@roots.config.locals, entry: entry)
+          @roots.config.locals.entry = entry
           compiler = _.find @roots.config.compilers, (c) ->
             _.contains(c.extensions, path.extname(template).substring(1))
-          compiler.renderFile(template, locals)
+          compiler.renderFile(template, @roots.config.locals)
             .then((res) => @util.write("#{t.path(entry)}.html", res.result))

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "coveralls": "2.x",
     "istanbul": "0.3.x",
     "mocha": "1.x",
-    "roots": "3.0.0-rc.11",
+    "roots": "3.0.x",
     "mockery": "1.4.x"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -26,24 +26,17 @@ contentful = require 'roots-contentful'
 
 module.exports =
   extensions: [
-    contentful({
+    contentful
       access_token: 'YOUR_ACCESS_TOKEN'
       space_id: 'xxxxxx'
-      content_types: [
-        {
-          id: 'xxxxxx',
-          name: 'posts',
-          template: 'views/_post.jade',
-          filters: {
-            'fields.environment[in]': ['staging', 'production']
-          },
-          path: (e) -> "blogging/#{e.category}/#{slugify(e.title)}"
-        },
-        {
+      content_types:
+        blog_posts:
           id: 'xxxxxx'
-        }
-      ]
-    })
+          template: 'views/_post.jade'
+          filters: { 'fields.environment[in]': ['staging', 'production'] }
+          path: (e) -> "blogging/#{e.category}/#{slugify(e.title)}"
+        press_links:
+          id: 'xxxxxx'
   ]
 
 # ...
@@ -97,7 +90,9 @@ Required. The space ID containing the content you wish to retrieve.
 
 #### content_types
 
-An array of objects specifying from which Content Types you wish to fetch entries.
+An object whose key-value pairs correspond to a Contentful Content Types. Each
+content type's entries will be set on the `contentful` locals object using
+the key used in the config.
 
 ### Configuring a `content_type`  
 Each object in the content_types array can have the following properties:

--- a/test/fixtures/alt-content-type-config/app.coffee
+++ b/test/fixtures/alt-content-type-config/app.coffee
@@ -1,0 +1,12 @@
+contentful = require '../../..'
+
+module.exports =
+  ignores: ["**/_*", "**/.DS_Store"]
+  extensions: [
+    contentful
+      access_token: 'YOUR_ACCESS_TOKEN'
+      space_id: 'aqzq2qya2jm4'
+      content_types:
+        blog_posts:
+          id: '6BYT1gNiIEyIw8Og8aQAO6'
+  ]

--- a/test/fixtures/alt-content-type-config/index.jade
+++ b/test/fixtures/alt-content-type-config/index.jade
@@ -1,0 +1,5 @@
+ul
+  - for p in contentful.blog_posts
+    li
+      h1= p.title
+      p= p.body

--- a/test/fixtures/alt-content-type-config/package.json
+++ b/test/fixtures/alt-content-type-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -43,13 +43,25 @@ after -> h.project.remove_folders('**/public')
 # tests
 
 describe 'config', ->
-  before -> mock_contentful()
+  before ->
+    @title = 'Gatorade'
+    @body  = 'Yung Lean'
+    mock_contentful(entries: [{fields: {title: @title, body: @body}}])
 
   it 'should throw an error when missing an access token', ->
     (-> compile_fixture.call(@, 'missing_token')).should.throw()
 
   it 'should throw an error without content type id', ->
     compile_fixture.call(@, 'missing_config').should.be.rejected
+
+  it 'allows the content type name to be set through a k/v object config', (done) ->
+    compile_fixture.call(@, 'alt-content-type-config')
+      .with(@)
+      .then ->
+        p = path.join(@public, 'index.html')
+        h.file.contains(p, @title).should.be.true
+        h.file.contains(p, @body).should.be.true
+      .then(-> done()).catch(done)
 
   after -> unmock_contentful()
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -27,8 +27,6 @@ mock_contentful = (opts = {}) ->
       name: 'Blog Post'
       displayField: 'title'
 
-  if opts.entry then opts.entries = [opts.entry]
-
   mockery.registerMock 'contentful',
     createClient: ->
       contentType: -> W.resolve(opts.content_type)
@@ -56,7 +54,7 @@ describe 'config', ->
   after -> unmock_contentful()
 
 describe 'contentful content type fields', ->
-  before -> mock_contentful(entry: {fields: {sys: 'test'}})
+  before -> mock_contentful(entries: [{fields: {sys: 'test'}}])
 
   it 'should throw an error if `sys` is a field name', ->
     compile_fixture.call(@, 'basic').should.be.rejected
@@ -67,7 +65,7 @@ describe 'basic compile', ->
   before (done) ->
     @title = 'Throw Some Ds'
     @body  = 'Rich Boy selling crick'
-    mock_contentful(entry: {fields: {title: @title, body: @body}})
+    mock_contentful(entries: [{fields: {title: @title, body: @body}}])
     compile_fixture.call(@, 'basic').then(-> done()).catch(done)
 
   it 'compiles basic project', ->
@@ -85,7 +83,7 @@ describe 'custom name for view helper local', ->
   before (done) ->
     @title = 'Throw Some Ds'
     @body  = 'Rich Boy selling crack'
-    mock_contentful(entry: {fields: {title: @title, body: @body}})
+    mock_contentful(entries: [{fields: {title: @title, body: @body}}])
     compile_fixture.call(@, 'custom_name').then(-> done()).catch(done)
 
   it 'has contentful data available in views under a custom name', ->
@@ -101,7 +99,7 @@ describe 'single entry views', ->
       @title = 'Real Talk'
       @body  = 'I\'m not about to sit up here, and argue about who\'s to blame.'
       mock_contentful
-        entry: {fields: {title: @title, body: @body}},
+        entries: [{fields: {title: @title, body: @body}}],
         content_type: {name: 'Blog Post', displayField: 'title'}
       compile_fixture.call(@, 'single_entry').then(-> done()).catch(done)
 
@@ -148,7 +146,7 @@ describe 'single entry views', ->
       @body  = 'I\'m not about to sit up here, and argue about who\'s to blame.'
       @category = 'greatest_hits'
       mock_contentful
-        entry: {fields: {title: @title, body: @body, category: @category}},
+        entries: [{fields: {title: @title, body: @body, category: @category}}],
         content_type: {name: 'Blog Post', displayField: 'title'}
       compile_fixture.call(@, 'single_entry_custom').then(-> done()).catch(done)
 


### PR DESCRIPTION
Updates the `content_types` config to accept an object as well. The given key is also used as the key on the `contentful` object in your views. Updates the readme to use this more elegant config.

```coffee
contentful({
  access_token: 'YOUR_ACCESS_TOKEN'
  space_id: 'xxxxxx'
  content_types: [
    {
      id: 'xxxxxx',
      name: 'posts',
      template: 'views/_post.jade',
      filters: {
        'fields.environment[in]': ['staging', 'production']
      },
      path: (e) -> "blogging/#{e.category}/#{slugify(e.title)}"
    },
    {
      id: 'xxxxxx'
    }
  ]
})
```
can become:
```coffee
contentful
  access_token: 'YOUR_ACCESS_TOKEN'
  space_id: 'xxxxxx'
  content_types:
    blog_posts:
      id: 'xxxxxx'
      template: 'views/_post.jade'
      filters: { 'fields.environment[in]': ['staging', 'production'] }
      path: (e) -> "blogging/#{e.category}/#{slugify(e.title)}"
    press_links:
      id: 'xxxxxx'

```