### PR TITLE
Asset view helper

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -162,14 +162,4 @@ module.exports = (opts) ->
       asset.fields ?= {}
       asset.fields.file ?= {}
       url = asset.fields.file.url
-      if opts then append_query_string(url, opts) else url
-
-    ###*
-     * Appends query string params to a given URL string
-     * @param {String} url - URL string
-     * @param {Object} opts - Query string params to append
-     * @return {String} - resulting URL string
-    ###
-
-    append_query_string = (url, args = {}) ->
-      "#{url}?#{querystring.stringify(args)}"
+      if opts then "#{url}?#{querystring.stringify(opts)}" else url

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -29,6 +29,7 @@ module.exports = (opts) ->
       @util = new RootsUtil(@roots)
       @roots.config.locals ?= {}
       @roots.config.locals.contentful ?= {}
+      @roots.config.locals.asset = asset_view_helper
 
     setup: ->
       configure_content(opts.content_types).with(@)
@@ -147,3 +148,31 @@ module.exports = (opts) ->
             _.contains(c.extensions, path.extname(template).substring(1))
           compiler.renderFile(template, @roots.config.locals)
             .then((res) => @util.write("#{t.path(entry)}.html", res.result))
+
+    ###*
+     * View helper for accessing the actual url from a Contentful asset
+     * and appends any query string params
+     * @param {Object} asset - Asset object returned from Contentful API
+     * @param {Object} opts - Query string params to append to the URL
+     * @return {String} - URL string for the asset
+    ###
+
+    asset_view_helper = (asset, opts) ->
+      if not asset.fields then return ''
+      url = asset.fields.file.url
+      if opts then append_query_string(url, opts) else url
+
+    ###*
+     * Appends query string params to a given URL string
+     * @param {String} url - URL string
+     * @param {Object} opts - Query string params to append
+     * @return {String} - resulting URL string
+    ###
+
+    append_query_string = (url, args = {}) ->
+      url += '?'
+      for k, v of args
+        url += "#{k}=#{v}&"
+      if url[url.length - 1] == '&'
+        url = url.substring(0, url.length - 1)
+      return url

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,10 +1,11 @@
-_          = require 'lodash'
-W          = require 'when'
-S          = require 'string'
-path       = require 'path'
-contentful = require 'contentful'
-pluralize  = require 'pluralize'
-RootsUtil  = require 'roots-util'
+_           = require 'lodash'
+W           = require 'when'
+S           = require 'string'
+path        = require 'path'
+contentful  = require 'contentful'
+pluralize   = require 'pluralize'
+RootsUtil   = require 'roots-util'
+querystring = require 'querystring'
 
 errors =
   no_token: 'Missing required options for roots-contentful. Please ensure
@@ -157,8 +158,9 @@ module.exports = (opts) ->
      * @return {String} - URL string for the asset
     ###
 
-    asset_view_helper = (asset, opts) ->
-      if not asset.fields then return ''
+    asset_view_helper = (asset = {}, opts) ->
+      asset.fields ?= {}
+      asset.fields.file ?= {}
       url = asset.fields.file.url
       if opts then append_query_string(url, opts) else url
 
@@ -170,9 +172,4 @@ module.exports = (opts) ->
     ###
 
     append_query_string = (url, args = {}) ->
-      url += '?'
-      for k, v of args
-        url += "#{k}=#{v}&"
-      if url[url.length - 1] == '&'
-        url = url.substring(0, url.length - 1)
-      return url
+      "#{url}?#{querystring.stringify(args)}"

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -158,8 +158,8 @@ module.exports = (opts) ->
      * @return {String} - URL string for the asset
     ###
 
-    asset_view_helper = (asset = {}, opts) ->
+    asset_view_helper = (asset = {}, params) ->
       asset.fields ?= {}
       asset.fields.file ?= {}
       url = asset.fields.file.url
-      if opts then "#{url}?#{querystring.stringify(opts)}" else url
+      if params then "#{url}?#{querystring.stringify(params)}" else url

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "2.4.x",
+    "lodash": "3.6.x",
     "roots-util": "0.1.x",
-    "contentful": "0.1.x",
-    "when": "3.4.x",
-    "string": "~1.9.x",
-    "pluralize": "0.0.10"
+    "contentful": "1.1.x",
+    "when": "3.7.x",
+    "string": "3.1.x",
+    "pluralize": "1.1.x"
   },
   "devDependencies": {
-    "chai": "1.x",
+    "chai": "2.x",
     "chai-as-promised": "4.x",
     "coffee-script": "1.7.x",
     "coveralls": "2.x",

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,16 @@ Optional. Takes an object with different filter criteria, see examples of how to
 
 Optional. Provide a function that returns a string of the relative path to the output file for a given entry without the extension. First argument passed into the function is the entry. Default is `<name>/<slug>` where `slug` is the [slugified](http://stringjs.com/#methods/slugify) output of the entry's `displayField` (a property of the Content Type), and `name` is the provided `name` option above or the default value. This option is ignored if no `template` is given.
 
+
+### Asset Image Helper
+
+roots-contentful also provides a convenient view helper called `asset` that allows you to pass in the asset object returned from their API and returns the url. You can also pass in options that will be appended to the image url as a a query string that allows you to specificy size and quality params as documented [here](https://www.contentful.com/developers/documentation/content-delivery-api/javascript/#image-asset-resizing).
+
+```jade
+- for post in contentful.posts
+  img(src!= asset(post.image, {w: 100, h: 100, q: 50}))
+```
+
 ### License & Contributing
 
 - Details on the license [can be found here](LICENSE.md)

--- a/test/fixtures/image_view_helper/app.coffee
+++ b/test/fixtures/image_view_helper/app.coffee
@@ -1,0 +1,18 @@
+contentful = require '../../..'
+
+module.exports =
+  ignores: ["**/_*", "**/.DS_Store"]
+  extensions: [
+    contentful(
+      access_token: 'YOUR_ACCESS_TOKEN'
+      space_id: 'aqzq2qya2jm4'
+      content_types: [
+        {
+          id: '6BYT1gNiIEyIw8Og8aQAO6'
+        }
+        {
+          id: '7CDlVsacqQc88cmIEGYWMa'
+        }
+      ]
+    )
+  ]

--- a/test/fixtures/image_view_helper/index.jade
+++ b/test/fixtures/image_view_helper/index.jade
@@ -1,0 +1,4 @@
+ul
+  - for p in contentful.blog_posts
+    li
+      img(src!= asset(p.image, {w: 100, h: 100}))

--- a/test/fixtures/image_view_helper/package.json
+++ b/test/fixtures/image_view_helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -170,3 +170,16 @@ describe 'single entry views', ->
       h.file.contains(p, @body).should.be.true
 
     after -> unmock_contentful()
+
+  describe 'image view helper function', ->
+    before (done) ->
+      @img_path = 'http://dogesay.com/wow.jpg'
+      mock_contentful
+        entries: [{fields: {image: fields: {file: {url: @img_path}}}}]
+      compile_fixture.call(@, 'image_view_helper').then(-> done()).catch(done)
+
+    it 'adds query string params to the image', ->
+      p = path.join(@public, 'index.html')
+      h.file.contains(p, "#{@img_path}?w=100&h=100").should.be.true
+
+    after -> unmock_contentful()


### PR DESCRIPTION
This adds an asset view helper as to support the API options discussed in #10. This convenience helper allows you to pass in the full asset object and get the URL (instead of having to write `image.fields.file.url`) as well as pass in an options hash like `{w: 100, h: 100}` that'll be appended to the end of the asset url as a query string.

Closes #10 