### PR TITLE
Added support for using the contentful preview API

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -15,6 +15,11 @@ errors =
   reserved for storing Contentful system metadata, please rename this field to
   a different value.'
 
+hosts = {
+  develop: 'preview.contentful.com',
+  production: 'cdn.contentful.com'
+}
+
 module.exports = (opts) ->
   # throw error if missing required config
   if not (opts.access_token && opts.space_id)
@@ -22,6 +27,7 @@ module.exports = (opts) ->
 
   # setup contentful api client
   client = contentful.createClient
+    host: hosts[process.env.CONTENTFUL_ENV] || hosts.production
     accessToken: opts.access_token
     space:       opts.space_id
 


### PR DESCRIPTION
Setting CONTENTFUL_ENV environment variable to 'production' will use the preview API. Defaults to 
the production API, so should not break any existing apps