### PR TITLE
Fix syntax regression causing  missing accessToken data

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -26,11 +26,12 @@ module.exports = (opts) ->
 
   # setup contentful api client
   client = contentful.createClient
-    host: hosts[process.env.CONTENTFUL_ENV] ||
-          hosts.develop if opts.preview ||
-          hosts.production
+    host:
+      hosts[process.env.CONTENTFUL_ENV] ||
+      (hosts.develop if opts.preview)   ||
+      hosts.production
     accessToken: opts.access_token
-    space:       opts.space_id
+    space: opts.space_id
 
   class RootsContentful
     constructor: (@roots) ->


### PR DESCRIPTION
This fixes an error whereby running `roots watch` would result in `[TypeError: Expected accessToken]`.

The bug was introduced in https://github.com/carrot/roots-contentful/commit/fb3382a90416288c710fece6fd8b9392ea0f95ab due to a simple coffeescript syntax regression error causing the compiled `client` assignee to be assigned two objects rather than one:

```js
var client;

client = contentful.createClient(opts.preview || hosts.production ? {
  host: hosts[process.env.CONTENTFUL_ENV] || hosts.develop
} : void 0, {
  accessToken: opts.access_token,
  space: opts.space_id
});
```

Ideally, this is the syntax we want after compile:

```js
var client;

client = contentful.createClient({
  host: hosts[process.env.CONTENTFUL_ENV] || (opts.preview ? hosts.develop : void 0) || hosts.production,
  accessToken: opts.access_token,
  space: opts.space_id
});
```

This PR fixes the syntax regression and produces the code in the second example.