### PR TITLE
Four functionality additions to make roots-contentful more flexible

### DIFF
--- a/test/fixtures/namespace/app.coffee
+++ b/test/fixtures/namespace/app.coffee
@@ -1,0 +1,20 @@
+contentful = require '../../..'
+
+module.exports =
+  ignores: ["**/_*", "**/.DS_Store"]
+  extensions: [
+    contentful(
+      namespace: 'custom'
+      access_token: 'YOUR_ACCESS_TOKEN'
+      space_id: 'aqzq2qya2jm4'
+      content_types: [
+        {
+          id: '6BYT1gNiIEyIw8Og8aQAO6',
+        },
+        {
+          namespace: 'custom2'
+          id: '6BYT1gNiIEyIw8Og8aQAO6',
+        }
+      ]
+    )
+  ]

--- a/test/fixtures/namespace/index.jade
+++ b/test/fixtures/namespace/index.jade
@@ -1,0 +1,10 @@
+ul
+  - for p in custom.blog_posts
+    li
+      h1= p.title
+      p= p.body
+  
+  - for p in custom2.blog_posts
+     li
+       h1= p.title_2
+       p= p.body_2

--- a/test/fixtures/namespace/package.json
+++ b/test/fixtures/namespace/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/fixtures/set_locals/app.coffee
+++ b/test/fixtures/set_locals/app.coffee
@@ -1,0 +1,19 @@
+contentful = require '../../..'
+
+module.exports =
+  ignores: ["**/_*", "**/.DS_Store"]
+  extensions: [
+    contentful(
+      access_token: 'YOUR_ACCESS_TOKEN'
+      space_id: 'aqzq2qya2jm4'
+      content_types: [
+        {
+          name: 'local_test'
+          id: '6BYT1gNiIEyIw8Og8aQAO6',
+          write: 'posts.json',
+          set_locals: (content_type) ->
+            return {specific_local: content_type.content[0].body}
+        },
+      ]
+    )
+  ]

--- a/test/fixtures/set_locals/index.jade
+++ b/test/fixtures/set_locals/index.jade
@@ -1,0 +1,1 @@
+h1= contentful.local_test.specific_local

--- a/test/fixtures/set_locals/package.json
+++ b/test/fixtures/set_locals/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/fixtures/single_entry_custom/app.coffee
+++ b/test/fixtures/single_entry_custom/app.coffee
@@ -12,7 +12,9 @@ module.exports =
           id: '6BYT1gNiIEyIw8Og8aQAO6'
           name: 'blog_posts'
           template: 'views/_blog_post.jade'
-          path: (e) -> "blogging/#{e.category}/#{S(e.title).slugify().s}"
+          path: (e, locals) ->
+            category = locals.contentful['blog_posts'][0].category
+            return "blogging/#{category}/#{S(e.title).slugify().s}"
         }
       ]
     )

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -186,6 +186,46 @@ describe 'data manipulation', ->
 
     after -> unmock_contentful()
 
+  describe 'custom namespace', ->
+    before (done) ->
+      @title = 'Throw Some Ds'
+      @body  = 'Rich Boy selling crack'
+      @title_2 = 'Yes sir'
+      @body_2 = 'No mum'
+
+      mock_contentful
+        entries: [
+          {fields: {title: @title, body: @body}}
+          {fields: {title: @title_2, body: @body_2}}
+        ]
+      compile_fixture.call(@, 'namespace').then(-> done()).catch(done)
+
+    it 'has contentful data available in views under a custom global namespace', ->
+      p = path.join(@public, 'index.html')
+      h.file.contains(p, @title).should.be.true
+      h.file.contains(p, @body).should.be.true
+
+    it 'has contentful data available in views under a custom local(type) namespace', ->
+      p = path.join(@public, 'index.html')
+      h.file.contains(p, @title_2).should.be.true
+      h.file.contains(p, @body_2).should.be.true
+
+    after -> unmock_contentful()
+
+  describe 'set_locals', ->
+    before (done) ->
+      @title = 'Throw Some Ds'
+      @body  = 'Rich Boy selling crack'
+
+      mock_contentful entries: [{fields: {title: @title, body: @body}}]
+      compile_fixture.call(@, 'set_locals').then(-> done()).catch(done)
+
+    it 'can set custom content_type locals', ->
+      p = path.join(@public, 'index.html')
+      h.file.contains(p, @body).should.be.true
+
+    after -> unmock_contentful()
+
 describe 'custom name for view helper local', ->
   before (done) ->
     @title = 'Throw Some Ds'


### PR DESCRIPTION
1. **Added ability to namespace**
    Now you can specify were "content_type's" are attached globally and per content_type, rather than always getting assign to "contentful".

2. **Content_type now has 'set_locals' function**
    Basically ability to set "content_type" locals manually rather than always automatically

3. **Path function now has second parameter passed containing all content types(deep cloned)**
   Very useful when you need 'data' form other content_type for curren type's path generation.., i.e having `meta` content_type, on which other content_type may depend..

4. **Minor execution flow reordering**
    Basically set "urls"/ write files right before compilation, so that `path` fn, has all the data for really custom path generation..  