### PR TITLE
Path helper

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -343,9 +343,11 @@ async function compile_entries (types) {
       })
       return entry._urls.map(_url => {
         locals.entry = { ...entry, _url }
+        locals._path = _url // alias _url as _path in locals
         return compiler.renderFile(tpl_path, locals)
           .then(compiled => {
             locals.entry = null
+            locals._path = null
             return util.write(_url, compiled.result)
           })
       })

--- a/test/fixtures/single-entry--path-helper/app.coffee
+++ b/test/fixtures/single-entry--path-helper/app.coffee
@@ -1,0 +1,20 @@
+contentful = require '../../../src'
+
+module.exports =
+  ignores: ["**/_*", "**/.DS_Store"]
+  extensions: [
+    contentful(
+      access_token: 'YOUR_ACCESS_TOKEN'
+      space_id: 'aqzq2qya2jm4'
+      content_types: [
+        {
+          id: '6BYT1gNiIEyIw8Og8aQAO6'
+          name: 'blog_posts'
+          template: 'views/_blog_post.jade'
+        }
+      ]
+    )
+  ]
+
+  locals:
+    wow: 'such local'

--- a/test/fixtures/single-entry--path-helper/index.jade
+++ b/test/fixtures/single-entry--path-helper/index.jade
@@ -1,0 +1,4 @@
+- for p in contentful.blog_posts
+  h1= p.title
+  p= p.body
+  a(href= p._url) Link

--- a/test/fixtures/single-entry--path-helper/package.json
+++ b/test/fixtures/single-entry--path-helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test",
+  "dependencies": {
+    "jade": "*"
+  }
+}

--- a/test/fixtures/single-entry--path-helper/views/_blog_post.jade
+++ b/test/fixtures/single-entry--path-helper/views/_blog_post.jade
@@ -1,0 +1,4 @@
+h1= entry.title
+p= entry.body
+p= wow
+p= _path

--- a/test/single-entry/path-helper.js
+++ b/test/single-entry/path-helper.js
@@ -1,0 +1,33 @@
+import test from 'ava'
+import {
+  async,
+  helpers,
+  mock_contentful,
+  unmock_contentful,
+  compile_fixture
+} from '../helpers'
+
+let ctx = {}
+
+test.before(async t => {
+  let title = 'Wow such doge'
+  let body = 'such amaze'
+  ctx = { ...ctx, title, body }
+  mock_contentful({
+    entries: [
+      { fields: { title, body } }
+    ],
+    content_type: { name: 'Blog Post', displayField: 'title' }
+  })
+  await ctx::compile_fixture('single-entry--path-helper')
+  ctx.index_path = `${ctx.public_dir}/index.html`
+  ctx.post_path = `${ctx.public_dir}/blog_posts/wow-such-doge.html`
+})
+
+test('should expose _path helper in entries', async t => {
+  t.true(await helpers.file.contains(ctx.post_path, '/blog_posts/wow-such-doge.html', { async }))
+})
+
+test.after(async t => {
+  unmock_contentful()
+})


### PR DESCRIPTION
This aliases each single entry's `_url` local as `_path`, so that it is more consistent with Roots (which exposes a general `_path` local for regular template files) and can be more dynamically referenced in layout files

Since this was a very simple change, I think it's ready for merge /cc @kylemac 