### PR TITLE
add instructions for adding a markdown parser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,22 @@ A `contentful` view helper object will be passed into every view containing your
         p= markdown(post.body)
 ```
 
+Note: for the above `markdown` function to parse your `post.body`, you need to install a markdown parser for roots to work with. Using [marked](https://www.npmjs.com/package/marked) as an example, do the following:
+
+- `npm install marked --save`
+
+And then in `app.coffee`:
+
+```coffee
+contentful = require 'roots-contentful'
+marked     = require 'marked'
+
+locals:
+  marked: markdown
+```
+
+See the [roots documentation](http://roots.cx/docs/configuration) for more details.
+
 Note: if you have [Links](https://www.contentful.com/developers/docs/concepts/links/) in your content more than 10 levels deep (the max for the `include` parameter), then unresolved links can be returned.
 
 #### Single Entry Views

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ contentful = require 'roots-contentful'
 marked     = require 'marked'
 
 locals:
-  marked: markdown
+  markdown: marked
 ```
 
 See the [roots documentation](http://roots.cx/docs/configuration) for more details.


### PR DESCRIPTION
I noticed that people new to roots frequently trip over the `markdown(post.body)` function, so I added a block to the documentation. Hope it's helpful.

Thanks for roots and roots-contentful!