### PR TITLE
Fix obsolete client calls for contentful.js 3.x

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -63,7 +63,7 @@ module.exports = (opts) ->
         if not t.id then return W.reject(errors.no_type_id)
         t.filters ?= {}
         if (not t.name || (t.template && not t.path))
-          return W client.contentType(t.id).then (res) ->
+          return W client.getContentType(t.id).then (res) ->
             t.name ?= pluralize(S(res.name).toLowerCase().underscore().s)
             if t.template
               t.path ?= (e) -> "#{t.name}/#{S(e[res.displayField]).slugify().s}"
@@ -105,7 +105,7 @@ module.exports = (opts) ->
 
     fetch_content = (type) ->
       W(
-        client.entries(
+        client.getEntries(
           _.merge(type.filters, content_type: type.id, include: 10)
         )
       )


### PR DESCRIPTION
roots-contentful updated to contentful.js 3.x in April 2016, but the code still invokes old method names that no longer exist in contentful.js. The resulting error message is: 

> TypeError: client.entries is not a function

This change updates the client calls from client.entries() to client.getEntries(), and from client.contentType to client..getContentType.