### PR TITLE
fixes promise resolution in transform_entries

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -163,8 +163,10 @@ module.exports = (opts) ->
     transform_entries = (types) ->
       W.map types, (t) =>
         if t.transform
-          W.map t.content, (entry) =>
+          transformed = W.map t.content, (entry) =>
             W(entry, t.transform)
+          W.resolve(transformed)
+            
         W.resolve(t)
 
     ###*


### PR DESCRIPTION
This bug was able to slip by since the test was assuming a mutative strategy for the transform function. A nasty bug arises when you chose to NOT mutate the data and instead make copies because the original data is returned, meaning the `map` is not behaving as a map but instead a simple `forEach` loop. This resolves this. I can create a failing test case if that would be helpful.
